### PR TITLE
Add option to analyze minified bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ The following options are available:
 
 ```
 -a, --android         analyse Android bundle 
--d, --dev             analyse developement bundle
--m, --min             analyse minified bundle
+-d, --dev             analyse development bundle
 -o, --output [dir]    output directory
 -p, --port [port]     use custom port
 -j, --json            save output as JSON file instead of HTML

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The following options are available:
 ```
 -a, --android         analyse Android bundle 
 -d, --dev             analyse developement bundle
+-m, --min             analyse minified bundle
 -o, --output [dir]    output directory
 -p, --port [port]     use custom port
 -j, --json            save output as JSON file instead of HTML

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ commander
 	.version(packageJson.version, '-v, --version')
 	.option('-a, --android', 'Analyse Android bundle ')
 	.option('-d, --dev', 'Analyse developement bundle')
+	.option('-m, --min', 'Analyse minified bundle')
 	.option('-j, --json', 'Output JSON')
 	.option('-o, --output [dir]', 'Specify output dir', defaultDir)
 	.option('-p, --port [port]', 'Specify js package port')
@@ -30,7 +31,7 @@ const query = qs.stringify({
 	platform,
 	sourceMap: 'true',
 	dev: commander.dev ? 'true' : 'false',
-	minify: 'false',
+	minify: commander.min ? 'false' : 'false',
 	hot: 'false'
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,7 @@ const defaultDir = mkdtempSync(path.join(tempDir, 'npx-visualize-bundle'));
 commander
 	.version(packageJson.version, '-v, --version')
 	.option('-a, --android', 'Analyse Android bundle ')
-	.option('-d, --dev', 'Analyse developement bundle')
-	.option('-m, --min', 'Analyse minified bundle')
+	.option('-d, --dev', 'Analyse development bundle')
 	.option('-j, --json', 'Output JSON')
 	.option('-o, --output [dir]', 'Specify output dir', defaultDir)
 	.option('-p, --port [port]', 'Specify js package port')
@@ -30,8 +29,8 @@ const platform = commander.android ? 'android' : 'ios';
 const query = qs.stringify({
 	platform,
 	sourceMap: 'true',
-	dev: commander.dev ? 'true' : 'false',
-	minify: commander.min ? 'false' : 'false',
+	dev: String(Boolean(commander.dev)),
+	minify: String(!commander.dev),
 	hot: 'false'
 });
 


### PR DESCRIPTION
Measuring minified bundle size can be a more realistic way of keeping track of app bundle size and boot performance, especially given minification may be removing dead code paths.