### PR TITLE
Add support to analyse youi react-native bundles

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ const defaultReportName = 'report';
 commander
 	.version(packageJson.version, '-v, --version')
 	.option('-a, --android', 'Analyse Android bundle ')
+	.option('-y, --youi', 'Analyse Youi bundle ')
 	.option('-d, --dev', 'Analyse development bundle')
 	.option('-j, --json', 'Output JSON')
 	.option('-r, --report [string]', 'Custom name for the report file (without ext)', defaultReportName)
@@ -29,7 +30,11 @@ commander
 
 const sourceMapExplorer = require('source-map-explorer');
 
-const platform = commander.android ? 'android' : 'ios';
+const platform = commander.android
+	? 'android'
+	: commander.youi
+	? 'youi'
+      	: 'ios';
 
 const query = qs.stringify({
 	platform,


### PR DESCRIPTION
Link to the engine. https://www.youi.tv/youi-engine/react-native/

They provide support for TV platforms using react native and their proprietary c++ engine. The entry point is index.youi.js.